### PR TITLE
Make hook signature more open

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ A changelog:
 
 *Analogy: git blame :p*
 
+## dev version
+
+* Changed `Roll.hook` signature to also accept kwargs.
+
 ## 0.5.0 — 2017-09-21
 
 * Add documentation.

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -211,3 +211,33 @@ your virtualenv active), run:
 Then you can run the tests:
 
     py.test
+
+
+## How to send custom events
+
+Roll has a very small API for listening and sending events. It's possible to use
+it in your project for your own events.
+
+Events are useful when you want other users to extend your own code, whether
+it's a Roll extension, or a full project built with Roll.
+They differ from configuration in that they are more adapted for dynamic
+modularity.
+
+For example, say we develop a DB pooling extension for Roll. We
+would use a simple configuration parameter to let users change the connection
+credentials (host, username, password…). But if we want users to run some
+code each time a new connection is created, we may use a custom event.
+
+Our extension usage would look like this:
+
+    app = Roll()
+    db_pool_extension(app, dbname='mydb', username='foo', password='bar')
+
+    @app.listen('new_connection')
+    def listener(connection):
+        # dosomething with the connection,
+        # for example register some PostgreSQL custom types.
+
+Then, in our extension, when creating a new connection, we'd do something like
+that:
+    app.hook('new_connection', connection=connection)

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,8 @@ A how-to guide:
 * [How to return JSON content](how-to-guides.md#how-to-return-json-content)
 * [How to subclass Roll itself](how-to-guides.md#how-to-subclass-roll-itself)
 * [How to deploy Roll into production](how-to-guides.md#how-to-deploy-roll-into-production)
-* [How to run Roll’s tests](how-to-guides.md##how-to-run-rolls-tests)
+* [How to run Roll’s tests](how-to-guides.md#how-to-run-rolls-tests)
+* [How to send custom events](how-to-guides.md#how-to-send-custom-events)
 
 
 ## [Discussions](discussions.md)

--- a/roll/__init__.py
+++ b/roll/__init__.py
@@ -293,7 +293,7 @@ class Roll:
         try:
             for func in self.hooks[name]:
                 result = await func(*args, **kwargs)
-                if result:
+                if result:  # Allows to shortcut the chain.
                     return result
         except KeyError:
             # Nobody registered to this event, let's roll anyway.

--- a/roll/__init__.py
+++ b/roll/__init__.py
@@ -289,11 +289,11 @@ class Roll:
             self.hooks[name].append(func)
         return wrapper
 
-    async def hook(self, name: str, *kwargs):
+    async def hook(self, name: str, *args, **kwargs):
         try:
             for func in self.hooks[name]:
-                result = await func(*kwargs)
-                if result:  # Allows to shortcut the chain.
+                result = await func(*args, **kwargs)
+                if result:
                     return result
         except KeyError:
             # Nobody registered to this event, let's roll anyway.

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -57,3 +57,13 @@ async def test_error_with_json_format(client, app):
     assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
     error = json.loads(resp.body)
     assert error == {"status": 500, "message": "JSON error"}
+
+
+async def test_third_parties_can_call_hook_their_way(client, app):
+
+    @app.listen('custom')
+    async def listener(myarg):
+        return myarg
+
+    assert await app.hook('custom', myarg='kwarg') == 'kwarg'
+    assert await app.hook('custom', 'arg') == 'arg'


### PR DESCRIPTION
Third-party extensions/users may use hooks for their own needs.

An example is utilery: https://github.com/tilery/utilery/blob/async/utilery/core.py#L70