### PR TITLE
Prevent from running Travis twice on a PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ install:
 - python setup.py develop
 - pip install -r requirements-dev.txt
 script: py.test
+branches:
+  only:
+    - master
 notifications:
   email:
     on_failure: always


### PR DESCRIPTION
Now Travis is running twice: once for the commit, once for the PRs.
This will tell Travis to run on master commits only, plus on PRs.