### PR TITLE
Allow to set allowed headers for cors extension

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -67,8 +67,9 @@ for usage.
 Add [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)-related headers. Especially useful for APIs.
 
 You can set the `Access-Control-Allow-Origin` header with the `origin`
-parameter and the `Access-Control-Allow-Methods` header with the
-`methods` parameter (list).
+parameter, the `Access-Control-Allow-Methods` header with the
+`methods` parameter (list) and the `Access-Control-Allow-Headers` header
+with the `headers` parameter (list).
 
 
 ### `logger`

--- a/roll/extensions.py
+++ b/roll/extensions.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 from traceback import print_exc
 
 
-def cors(app, origin='*', methods=None):
+def cors(app, origin='*', methods=None, headers=None):
 
     @app.listen('response')
     async def add_cors_headers(request, response):
@@ -12,6 +12,9 @@ def cors(app, origin='*', methods=None):
         if methods is not None:
             allow_methods = ','.join(methods)
             response.headers['Access-Control-Allow-Methods'] = allow_methods
+        if headers is not None:
+            allow_headers = ','.join(headers)
+            response.headers['Access-Control-Allow-Headers'] = allow_headers
 
 
 def logger(app, level=logging.DEBUG, handler=None):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -46,6 +46,19 @@ async def test_custom_cors_methods(client, app):
     assert resp.headers['Access-Control-Allow-Methods'] == 'PATCH,PUT'
 
 
+async def test_custom_cors_headers(client, app):
+
+    extensions.cors(app, headers=['X-Powered-By', 'X-Requested-With'])
+
+    @app.route('/test')
+    async def get(req, resp):
+        resp.body = 'test response'
+
+    resp = await client.get('/test')
+    assert (resp.headers['Access-Control-Allow-Headers'] ==
+            'X-Powered-By,X-Requested-With')
+
+
 async def test_logger(client, app, capsys):
 
     # startup has yet been called, but logger extensions was not registered


### PR DESCRIPTION
Useful to avoid https://github.com/addok/addok/pull/403/files#diff-70efbaff5eb06c7c51d84eb49ce4c165R144 for instance