### PR TITLE
Explicit charset in json content type header

### DIFF
--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -115,7 +115,7 @@ regular JSON and set the appropriated content type:
 $ http :3579/hello/world
 HTTP/1.1 200 OK
 Content-Length: 17
-Content-Type: application/json
+Content-Type: application/json; charset=utf-8
 
 {
     "hello": "world"

--- a/roll/__init__.py
+++ b/roll/__init__.py
@@ -132,8 +132,8 @@ class Response:
         self._status = HTTPStatus(http_code)
 
     def json(self, value: dict):
-        # Shortcut from a dict to a JSON with proper content type.
-        self.headers['Content-Type'] = 'application/json'
+        # Shortcut from a dict to JSON with proper content type.
+        self.headers['Content-Type'] = 'application/json; charset=utf-8'
         self.body = json.dumps(value)
 
     json = property(None, json)

--- a/roll/testing.py
+++ b/roll/testing.py
@@ -8,7 +8,7 @@ class Client:
 
     # Default content type for request body encoding, change it to your own
     # taste if needed.
-    content_type = 'application/json'
+    content_type = 'application/json; charset=utf-8'
 
     def __init__(self, app):
         self.app = app

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -70,7 +70,7 @@ async def test_json_with_default_code(client, app):
         resp.json = {'key': 'value'}
 
     resp = await client.get('/test')
-    assert resp.headers['Content-Type'] == 'application/json'
+    assert resp.headers['Content-Type'] == 'application/json; charset=utf-8'
     assert json.loads(resp.body) == {'key': 'value'}
     assert resp.status == HTTPStatus.OK
 
@@ -83,7 +83,7 @@ async def test_json_with_custom_code(client, app):
         resp.status = 400
 
     resp = await client.get('/test')
-    assert resp.headers['Content-Type'] == 'application/json'
+    assert resp.headers['Content-Type'] == 'application/json; charset=utf-8'
     assert json.loads(resp.body) == {'key': 'value'}
     assert resp.status == HTTPStatus.BAD_REQUEST
 


### PR DESCRIPTION
Useful to avoid https://github.com/addok/addok/pull/403/files#diff-70efbaff5eb06c7c51d84eb49ce4c165R114

See https://stackoverflow.com/q/9254891 for discussion and note that it might have a security impact if not set? http://blog.portswigger.net/2016/11/json-hijacking-for-modern-web.html