### PR TITLE
Add an exception to deal with Set-Cookie header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 install:
 - python setup.py develop
 - pip install -r requirements-dev.txt
-script: py.test
+script: py.test -vv
 branches:
   only:
     - master

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,8 @@ A changelog:
 * Added `content_negociation` extension to reject unacceptable client requests
   based on the `Accept` header
   ([#21](https://github.com/pyrates/roll/pull/21))
+* Allow to set multiple `Set-Cookie` headers
+  ([#23](https://github.com/pyrates/roll/pull/23))
 * **Breaking changes**:
     * `options` extension is no more applied by default
       ([#16](https://github.com/pyrates/roll/pull/16))

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -61,6 +61,14 @@ response.status = 204
 response.status = http.HTTPStatus.OK
 ```
 - **headers** (`dict`): case sensitive HTTP headers
+
+*`Set-Cookie` exception*: if you want to set multiple `Set-Cookie` headers,
+use a list as value (see [rfc7230](https://tools.ietf.org/html/rfc7230#page-23))*:
+
+```python
+response.headers['Set-Cookie'] = ['cookie1=value', 'cookie2=value']
+```
+
 - **body** (`bytes`): raw Response body; if `str` body is set, Roll will convert
   to `bytes` on the fly
 

--- a/roll/testing.py
+++ b/roll/testing.py
@@ -6,8 +6,11 @@ import pytest
 
 class Transport:
 
+    def __init__(self):
+        self.data = b''
+
     def write(self, data):
-        ...
+        self.data += data
 
     def close(self):
         ...
@@ -44,16 +47,16 @@ class Client:
         if content_type:
             headers['Content-Type'] = content_type
         body, headers = self.encode_body(body, headers)
-        protocol = self.app.factory()
-        protocol.connection_made(Transport())
-        protocol.on_message_begin()
-        protocol.on_url(path.encode())
-        protocol.request.body = body
-        protocol.request.method = method
-        protocol.request.headers = headers
-        await self.app(protocol.request, protocol.response)
-        protocol.write()
-        return protocol.response
+        self.protocol = self.app.factory()
+        self.protocol.connection_made(Transport())
+        self.protocol.on_message_begin()
+        self.protocol.on_url(path.encode())
+        self.protocol.request.body = body
+        self.protocol.request.method = method
+        self.protocol.request.headers = headers
+        await self.app(self.protocol.request, self.protocol.response)
+        self.protocol.write()
+        return self.protocol.response
 
     async def get(self, path, **kwargs):
         return await self.request(path, method='GET', **kwargs)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -23,3 +23,46 @@ async def test_can_set_status_from_httpstatus(client, app):
 
     resp = await client.get('/test')
     assert resp.status == HTTPStatus.ACCEPTED
+
+
+async def test_write(client, app):
+
+    @app.route('/test')
+    async def get(req, resp):
+        resp.status = HTTPStatus.OK
+        resp.body = 'body'
+
+    await client.get('/test')
+    assert client.protocol.writer.data == \
+        b'HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nbody'
+
+
+async def test_write_set_cookie(client, app):
+
+    @app.route('/test')
+    async def get(req, resp):
+        resp.status = HTTPStatus.OK
+        resp.body = 'body'
+        resp.headers['Set-Cookie'] = 'name=value'
+
+    await client.get('/test')
+    data = client.protocol.writer.data
+    assert b'\r\nSet-Cookie: name=value\r\n' in data
+    assert b'\r\nContent-Length: 4\r\n' in data
+    assert b'\r\n\r\nbody' in data
+
+
+async def test_write_multiple_set_cookie(client, app):
+
+    @app.route('/test')
+    async def get(req, resp):
+        resp.status = HTTPStatus.OK
+        resp.body = 'body'
+        resp.headers['Set-Cookie'] = ['name=value', 'other=value2']
+
+    await client.get('/test')
+    data = client.protocol.writer.data
+    assert b'\r\nSet-Cookie: name=value\r\n' in data
+    assert b'\r\nSet-Cookie: other=value2\r\n' in data
+    assert b'\r\nContent-Length: 4\r\n' in data
+    assert b'\r\n\r\nbody' in data


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7230#page-23,
Set-Cookie is the only response header field that can appear
multiple times.
So let's deal with that as an exception to keep normal perf
in normal case.

