### PR TITLE
Normalize request headers to work around inconsistent casing from clients

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,9 @@ A changelog:
     * Removed Request.kwargs in favor of inheriting from dict, to store user
       data in a separate space
       ([#33](https://github.com/pyrates/roll/pull/33))
+    * Request headers are now normalized in upper case, to work around
+      inconsistent casing in clients
+      ([#24](https://github.com/pyrates/roll/pull/24))
 * Only set the body and Content-Length header when necessary
   ([#31](https://github.com/pyrates/roll/pull/31))
 * Added `cookies` support ([#28](https://github.com/pyrates/roll/pull/28))

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -56,10 +56,10 @@ extensions.content_negociation(app)
 
 @app.route('/test', accepts=['text/html', 'application/json'])
 async def get(req, resp):
-    if req.headers['Accept'] == 'text/html':
+    if req.headers['ACCEPT'] == 'text/html':
         resp.headers['Content-Type'] = 'text/html'
         resp.body = '<h1>accepted</h1>'
-    elif req.headers['Accept'] == 'application/json':
+    elif req.headers['ACCEPT'] == 'application/json':
         resp.json = {'status': 'accepted'}
 ```
 
@@ -306,7 +306,7 @@ from roll import Roll
 def auth_required(func):
 
     async def wrapper(request, response, *args, **kwargs):
-        auth = request.headers.get('Authorization', '')
+        auth = request.headers.get('AUTHORIZATION', '')
         # This is really naive, never do that at home!
         if b64decode(auth[6:]) != b'user:pwd':
             response.status = HTTPStatus.UNAUTHORIZED

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -44,7 +44,7 @@ especially useful for extensions.
 - **query** (`Query`): Query instance with parsed query string
 - **method** (`str`): HTTP verb
 - **body** (`bytes`): raw body as received by Roll
-- **headers** (`dict`): HTTP headers
+- **headers** (`dict`): HTTP headers normalized in upper case
 - **cookies** (`Cookies`): a [Cookies instance](#cookies) with request cookies
 - **route** (`Route`): a [Route instance](#Route) storing results from URL matching
 

--- a/roll/__init__.py
+++ b/roll/__init__.py
@@ -120,7 +120,7 @@ class Request(dict):
     @property
     def cookies(self):
         if self._cookies is None:
-            self._cookies = parse(self.headers.get('Cookie', ''))
+            self._cookies = parse(self.headers.get('COOKIE', ''))
         return self._cookies
 
 
@@ -189,7 +189,7 @@ class Protocol(asyncio.Protocol):
     # All on_xxx methods are in use by httptools parser.
     # See https://github.com/MagicStack/httptools#apis
     def on_header(self, name: bytes, value: bytes):
-        self.request.headers[name.decode()] = value.decode()
+        self.request.headers[name.decode().upper()] = value.decode()
 
     def on_body(self, body: bytes):
         self.request.body += body

--- a/roll/extensions.py
+++ b/roll/extensions.py
@@ -59,7 +59,7 @@ def content_negociation(app):
 
     @app.listen('request')
     async def reject_unacceptable_requests(request, response):
-        accept = request.headers.get('Accept')
+        accept = request.headers.get('ACCEPT')
         accepts = request.route.payload['accepts']
         if accept is None or get_best_match(accept, accepts) is None:
             raise HttpError(HTTPStatus.NOT_ACCEPTABLE)

--- a/roll/testing.py
+++ b/roll/testing.py
@@ -53,7 +53,8 @@ class Client:
         self.protocol.on_url(path.encode())
         self.protocol.request.body = body
         self.protocol.request.method = method
-        self.protocol.request.headers = headers
+        for key, value in headers.items():
+            self.protocol.on_header(key.encode(), value.encode())
         await self.app(self.protocol.request, self.protocol.response)
         self.protocol.write()
         return self.protocol.response

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 
 VERSION = (0, 6, 0)
 
-__author__ = 'Yohan Boniface'
+__author__ = 'Pyrates'
 __contact__ = "yohan.boniface@data.gouv.fr"
 __homepage__ = "https://github.com/pyrates/roll"
 __version__ = ".".join(map(str, VERSION))

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -190,10 +190,10 @@ async def test_get_accept_content_negociation_if_many(client, app):
 
     @app.route('/test', accepts=['text/html', 'application/json'])
     async def get(req, resp):
-        if req.headers['Accept'] == 'text/html':
+        if req.headers['ACCEPT'] == 'text/html':
             resp.headers['Content-Type'] = 'text/html'
             resp.body = '<h1>accepted</h1>'
-        elif req.headers['Accept'] == 'application/json':
+        elif req.headers['ACCEPT'] == 'application/json':
             resp.json = {'status': 'accepted'}
 
     resp = await client.get('/test', headers={'Accept': 'text/html'})

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -30,7 +30,28 @@ async def test_request_parse_simple_get_response(protocol):
         b'\r\n')
     assert protocol.request.method == 'GET'
     assert protocol.request.path == '/feeds'
-    assert protocol.request.headers['Accept'] == '*/*'
+    assert protocol.request.headers['ACCEPT'] == '*/*'
+
+
+async def test_request_headers_are_uppercased(protocol):
+    protocol.data_received(
+        b'GET /feeds HTTP/1.1\r\n'
+        b'Host: localhost:1707\r\n'
+        b'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:54.0) '
+        b'Gecko/20100101 Firefox/54.0\r\n'
+        b'Accept: */*\r\n'
+        b'Accept-Language: en-US,en;q=0.5\r\n'
+        b'Accept-Encoding: gzip, deflate\r\n'
+        b'Origin: http://localhost:7777\r\n'
+        b'Referer: http://localhost:7777/\r\n'
+        b'DNT: 1\r\n'
+        b'Connection: keep-alive\r\n'
+        b'\r\n')
+    assert protocol.request.headers['ACCEPT-LANGUAGE'] == 'en-US,en;q=0.5'
+    assert protocol.request.headers['ACCEPT'] == '*/*'
+    assert protocol.request.headers.get('HOST') == 'localhost:1707'
+    assert 'DNT' in protocol.request.headers
+    assert protocol.request.headers.get('accept') is None
 
 
 async def test_request_path_is_unquoted(protocol):


### PR DESCRIPTION
For the record, a cython version of a case insensitive headers class:

```cython
# cython: language_level=3

from cpython.dict cimport PyDict_DelItem, PyDict_SetItem, PyDict_GetItem, PyDict_Contains


cdef class UpperHeaders(dict):

    def __setitem__(self, str key, str value):
        PyDict_SetItem(self, key.upper(), value)

    def __getitem__(self, str key):
        return self.get(key)

    cpdef get(self, str key, default=None):
        key = key.upper()
        if PyDict_Contains(self, key):
            return <str>PyDict_GetItem(self, key.upper())
        return default

    def __delitem__(self, str key):
        PyDict_DelItem(self, key.upper())

    def __contains__(self, str key):
        return PyDict_Contains(self, key.upper())
```

But we arbitrated for now for a simpler version, which is normalizing once while parsing the headers, and documenting that convention.