### PR TITLE
Only set the Content-Length header when necessary

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,11 @@ A changelog:
 
 *Analogy: git blame :p*
 
+## In progress
+
+* Only set the Content-Length header when necessary
+  ([#31](https://github.com/pyrates/roll/pull/31))
+
 ## 0.6.0 — 2017-11-22
 
 * Changed `Roll.hook` signature to also accept kwargs

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ A changelog:
 
 ## In progress
 
-* Only set the Content-Length header when necessary
+* Only set the body and Content-Length header when necessary
   ([#31](https://github.com/pyrates/roll/pull/31))
 
 ## 0.6.0 — 2017-11-22

--- a/roll/__init__.py
+++ b/roll/__init__.py
@@ -219,8 +219,9 @@ class Protocol(asyncio.Protocol):
                     payload += b'%b: %b\r\n' % (key.encode(), str(v).encode())
             else:
                 payload += b'%b: %b\r\n' % (key.encode(), str(value).encode())
+        payload += b'\r\n'
         if self.response.body and not bodyless:
-            payload += b'\r\n%b' % self.response.body
+            payload += self.response.body
         self.writer.write(payload)
         if not self.parser.should_keep_alive():
             self.writer.close()

--- a/roll/testing.py
+++ b/roll/testing.py
@@ -79,6 +79,9 @@ class Client:
     async def options(self, path, **kwargs):
         return await self.request(path, method='OPTIONS', **kwargs)
 
+    async def connect(self, path, **kwargs):
+        return await self.request(path, method='CONNECT', **kwargs)
+
 
 @pytest.fixture
 def client(app, event_loop):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -24,7 +24,7 @@ async def test_can_set_status_from_httpstatus(client, app):
     resp = await client.get('/test')
     assert resp.status == HTTPStatus.ACCEPTED
     assert client.protocol.writer.data == \
-        b'HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n'
+        b'HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n\r\n'
 
 
 async def test_write(client, app):
@@ -46,7 +46,7 @@ async def test_write_get_204_no_content_type(client, app):
         resp.status = HTTPStatus.NO_CONTENT
 
     await client.get('/test')
-    assert client.protocol.writer.data == b'HTTP/1.1 204 No Content\r\n'
+    assert client.protocol.writer.data == b'HTTP/1.1 204 No Content\r\n\r\n'
 
 
 async def test_write_get_304_no_content_type(client, app):
@@ -56,7 +56,7 @@ async def test_write_get_304_no_content_type(client, app):
         resp.status = HTTPStatus.NOT_MODIFIED
 
     await client.get('/test')
-    assert client.protocol.writer.data == b'HTTP/1.1 304 Not Modified\r\n'
+    assert client.protocol.writer.data == b'HTTP/1.1 304 Not Modified\r\n\r\n'
 
 
 async def test_write_get_1XX_no_content_type(client, app):
@@ -66,7 +66,7 @@ async def test_write_get_1XX_no_content_type(client, app):
         resp.status = HTTPStatus.CONTINUE
 
     await client.get('/test')
-    assert client.protocol.writer.data == b'HTTP/1.1 100 Continue\r\n'
+    assert client.protocol.writer.data == b'HTTP/1.1 100 Continue\r\n\r\n'
 
 
 async def test_write_head_no_content_type(client, app):
@@ -76,7 +76,7 @@ async def test_write_head_no_content_type(client, app):
         resp.status = HTTPStatus.OK
 
     await client.head('/test')
-    assert client.protocol.writer.data == b'HTTP/1.1 200 OK\r\n'
+    assert client.protocol.writer.data == b'HTTP/1.1 200 OK\r\n\r\n'
 
 
 async def test_write_connect_no_content_type(client, app):
@@ -86,7 +86,7 @@ async def test_write_connect_no_content_type(client, app):
         resp.status = HTTPStatus.OK
 
     await client.connect('/test')
-    assert client.protocol.writer.data == b'HTTP/1.1 200 OK\r\n'
+    assert client.protocol.writer.data == b'HTTP/1.1 200 OK\r\n\r\n'
 
 
 async def test_write_set_cookie(client, app):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -24,7 +24,7 @@ async def test_can_set_status_from_httpstatus(client, app):
     resp = await client.get('/test')
     assert resp.status == HTTPStatus.ACCEPTED
     assert client.protocol.writer.data == \
-        b'HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n\r\n'
+        b'HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n'
 
 
 async def test_write(client, app):
@@ -46,7 +46,7 @@ async def test_write_get_204_no_content_type(client, app):
         resp.status = HTTPStatus.NO_CONTENT
 
     await client.get('/test')
-    assert client.protocol.writer.data == b'HTTP/1.1 204 No Content\r\n\r\n'
+    assert client.protocol.writer.data == b'HTTP/1.1 204 No Content\r\n'
 
 
 async def test_write_get_304_no_content_type(client, app):
@@ -56,7 +56,7 @@ async def test_write_get_304_no_content_type(client, app):
         resp.status = HTTPStatus.NOT_MODIFIED
 
     await client.get('/test')
-    assert client.protocol.writer.data == b'HTTP/1.1 304 Not Modified\r\n\r\n'
+    assert client.protocol.writer.data == b'HTTP/1.1 304 Not Modified\r\n'
 
 
 async def test_write_get_1XX_no_content_type(client, app):
@@ -66,7 +66,7 @@ async def test_write_get_1XX_no_content_type(client, app):
         resp.status = HTTPStatus.CONTINUE
 
     await client.get('/test')
-    assert client.protocol.writer.data == b'HTTP/1.1 100 Continue\r\n\r\n'
+    assert client.protocol.writer.data == b'HTTP/1.1 100 Continue\r\n'
 
 
 async def test_write_head_no_content_type(client, app):
@@ -76,7 +76,7 @@ async def test_write_head_no_content_type(client, app):
         resp.status = HTTPStatus.OK
 
     await client.head('/test')
-    assert client.protocol.writer.data == b'HTTP/1.1 200 OK\r\n\r\n'
+    assert client.protocol.writer.data == b'HTTP/1.1 200 OK\r\n'
 
 
 async def test_write_connect_no_content_type(client, app):
@@ -86,7 +86,7 @@ async def test_write_connect_no_content_type(client, app):
         resp.status = HTTPStatus.OK
 
     await client.connect('/test')
-    assert client.protocol.writer.data == b'HTTP/1.1 200 OK\r\n\r\n'
+    assert client.protocol.writer.data == b'HTTP/1.1 200 OK\r\n'
 
 
 async def test_write_set_cookie(client, app):


### PR DESCRIPTION
Fix #26 

> A server MAY send a Content-Length header field in a response to a
   HEAD request (Section 4.3.2 of [RFC7231]); a server MUST NOT send
   Content-Length in such a response unless its field-value equals the
   decimal number of octets that would have been sent in the payload
   body of a response if the same request had used the GET method.

 >  A server MAY send a Content-Length header field in a 304 (Not
   Modified) response to a conditional GET request (Section 4.1 of
   [RFC7232]); a server MUST NOT send Content-Length in such a response
   unless its field-value equals the decimal number of octets that would
   have been sent in the payload body of a 200 (OK) response to the same
   request.

>   A server MUST NOT send a Content-Length header field in any response
   with a status code of 1xx (Informational) or 204 (No Content).  A
   server MUST NOT send a Content-Length header field in any 2xx
   (Successful) response to a CONNECT request (Section 4.3.6 of
   [RFC7231]).

 >  Aside from the cases defined above, in the absence of
   Transfer-Encoding, an origin server SHOULD send a Content-Length
   header field when the payload body size is known prior to sending the
   complete header section.  This will allow downstream recipients to
   measure transfer progress, know when a received message is complete,
   and potentially reuse the connection for additional requests.

😱 