### PR TITLE
Make Query instanciation lazy

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,15 @@ A changelog:
 
 *Analogy: git blame :p*
 
+## In progress
+
+* **Breaking changes**:
+    * `Request` and `Response` classes now take `app` as init parameter. It
+      allows lazy parsing of the query while keeping the `Query` class reference
+      on `Roll` application.
+      ([#35](https://github.com/pyrates/roll/pull/35))
+
+
 ## 0.7.0 - 2017-11-27
 
 * **Breaking changes**:

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -324,7 +324,7 @@ async def test_request_get_unknown_cookie_key_raises_keyerror(protocol):
 
 
 async def test_can_store_arbitrary_keys_on_request():
-    request = Request()
+    request = Request(None)
     request['custom'] = 'value'
     assert 'custom' in request
     assert request['custom'] == 'value'


### PR DESCRIPTION
It's about 4000 req/s on the benchmark when it does not access `request.query`, and there is no impact when it does.