### PR TITLE
Add apistar in benchmarks

### DIFF
--- a/benchmarks/apistar/app.py
+++ b/benchmarks/apistar/app.py
@@ -1,0 +1,21 @@
+import asyncio
+import logging
+
+import uvloop
+from apistar import Route
+# from apistar.frameworks.wsgi import WSGIApp as App
+from apistar.frameworks.asyncio import ASyncIOApp as App
+
+asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+logging.getLogger('asyncio').setLevel(logging.CRITICAL)
+
+
+async def minimal():
+    return {'message': 'Hello, World!'}
+
+
+routes = [
+    Route('/hello/minimal', 'GET', minimal),
+]
+
+app = App(routes=routes)

--- a/benchmarks/apistar/gunicorn.conf
+++ b/benchmarks/apistar/gunicorn.conf
@@ -1,0 +1,2 @@
+loglevel = 'critical'
+worker_class = 'meinheld.gmeinheld.MeinheldWorker'

--- a/benchmarks/apistar/run.sh
+++ b/benchmarks/apistar/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# exec gunicorn app:app --workers $WORKERS --threads $WORKERS --config gunicorn.conf
+exec uvicorn app:app --workers $WORKERS --threads $WORKERS

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,7 +1,9 @@
 aiohttp==2.2.4
+apistar==0.3.9
 falcon==1.2.0
 httpie==0.9.9
 gunicorn==19.7.1
 sanic==0.6.0
 ujson==1.35
+uvicorn==0.0.15
 uvloop==0.8.0


### PR DESCRIPTION
Given their [emphasis](https://github.com/encode/apistar#performance) on performance, I was curious to compare the "serve json" benchmark.

```
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
Running bench for apistar on minimal endpoint with 1 worker(s)
[2017-11-28 22:12:14 +0100] [23738] [INFO] Starting gunicorn 19.7.1
[2017-11-28 22:12:14 +0100] [23738] [INFO] Listening at: http://127.0.0.1:8000 (23738)
[2017-11-28 22:12:14 +0100] [23738] [INFO] Using worker: uvicorn 0.0.15
[2017-11-28 22:12:14 +0100] [23745] [INFO] Booting worker with pid: 23745
HTTP/1.1 200 OK
content-length: 28
content-type: application/json
date: Tue, 28 Nov 2017 21:12:14 GMT
server: uvicorn

{
    "message": "Hello, World!"
}

Running 10s test @ http://127.0.0.1:8000/hello/minimal
  20 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     9.43ms    2.09ms  34.09ms   95.33%
    Req/Sec   535.74     54.07   606.00     80.75%
  106725 requests in 10.01s, 15.57MB read
Requests/sec:  10660.79
Transfer/sec:      1.56MB

real	0m10,018s
user	0m0,227s
sys	0m1,107s
[2017-11-28 22:12:25 +0100] [23738] [INFO] Handling signal: term
[2017-11-28 22:12:25 +0100] [23745] [INFO] Error while closing socket [Errno 9] Bad file descriptor
[2017-11-28 22:12:25 +0100] [23745] [INFO] Worker exiting (pid: 23745)
[2017-11-28 22:12:25 +0100] [23738] [INFO] Shutting down: Master
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
```

vs

```
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
Running bench for roll on minimal endpoint with 1 worker(s)
HTTP/1.1 200 OK
Content-Length: 27
Content-Type: application/json; charset=utf-8

{
    "message": "Hello, World!"
}

Running 10s test @ http://127.0.0.1:8000/hello/minimal
  20 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.52ms  332.02us  17.67ms   94.58%
    Req/Sec     1.99k   301.21     9.89k    99.55%
  397500 requests in 10.10s, 40.56MB read
Requests/sec:  39355.69
Transfer/sec:      4.02MB

real	0m10,107s
user	0m0,511s
sys	0m2,811s
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
```