### PR TITLE
Decoupling of the Protocol I/O

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
-from roll import Roll, WSRoll
+from roll import Roll
+from roll.websockets import websockets
 from roll.extensions import traceback
 
 
@@ -8,11 +9,5 @@ from roll.extensions import traceback
 def app():
     app_ = Roll()
     traceback(app_)
-    return app_
-
-
-@pytest.fixture(scope='function')
-def wsapp():
-    app_ = WSRoll()
-    traceback(app_)
+    websockets(app_)
     return app_

--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,18 @@
 import pytest
 
-from roll import Roll
+from roll import Roll, WSRoll
 from roll.extensions import traceback
 
 
 @pytest.fixture(scope='function')
 def app():
     app_ = Roll()
+    traceback(app_)
+    return app_
+
+
+@pytest.fixture(scope='function')
+def wsapp():
+    app_ = WSRoll()
     traceback(app_)
     return app_

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ biscuits==0.1.1
 httptools==0.0.10
 multifruits==0.1.0
 uvloop==0.9.1
+websockets==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ httptools==0.0.10
 multifruits==0.1.0
 uvloop==0.9.1
 websockets==4.0.1
-aiohttp==3.0.6
+requests==2.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ httptools==0.0.10
 multifruits==0.1.0
 uvloop==0.9.1
 websockets==4.0.1
+aiohttp==3.0.6

--- a/roll/__init__.py
+++ b/roll/__init__.py
@@ -8,17 +8,17 @@ If you do not understand why something is not working as expected,
 please submit an issue (or even better a pull-request with at least
 a test failing): https://github.com/pyrates/roll/issues/new
 """
-import asyncio
+from asyncio import ensure_future, CancelledError
 from collections import namedtuple
 from http import HTTPStatus
 from io import BytesIO
 from typing import TypeVar
-from urllib.parse import parse_qs, unquote
-
+from urllib.parse import parse_qs
 from autoroutes import Routes
 from biscuits import Cookie, parse
-from httptools import HttpParserError, HttpRequestParser, parse_url
 from multifruits import Parser, extract_filename, parse_content_disposition
+from .protocols import Protocol, WSProtocol, ConnectionClosed
+
 
 try:
     # In case you use json heavily, we recommend installing
@@ -300,87 +300,7 @@ class Response:
             self._cookies = self.app.Cookies()
         return self._cookies
 
-
-class Protocol(asyncio.Protocol):
-    """Responsible of parsing the request and writing the response."""
-
-    __slots__ = ('app', 'request', 'parser', 'response', 'writer')
-    _BODYLESS_METHODS = ('HEAD', 'CONNECT')
-    _BODYLESS_STATUSES = (HTTPStatus.CONTINUE, HTTPStatus.SWITCHING_PROTOCOLS,
-                          HTTPStatus.PROCESSING, HTTPStatus.NO_CONTENT,
-                          HTTPStatus.NOT_MODIFIED)
-    RequestParser = HttpRequestParser
-
-    def __init__(self, app):
-        self.app = app
-        self.parser = self.RequestParser(self)
-
-    def data_received(self, data: bytes):
-        try:
-            self.parser.feed_data(data)
-        except HttpParserError:
-            # If the parsing failed before on_message_begin, we don't have a
-            # response.
-            self.response = self.app.Response(self.app)
-            self.response.status = HTTPStatus.BAD_REQUEST
-            self.response.body = b'Unparsable request'
-            self.write()
-
-    def connection_made(self, transport):
-        self.writer = transport
-
-    # All on_xxx methods are in use by httptools parser.
-    # See https://github.com/MagicStack/httptools#apis
-    def on_header(self, name: bytes, value: bytes):
-        self.request.headers[name.decode().upper()] = value.decode()
-
-    def on_body(self, body: bytes):
-        # FIXME do not put all body in RAM blindly.
-        self.request.body += body
-
-    def on_url(self, url: bytes):
-        self.request.url = url
-        parsed = parse_url(url)
-        self.request.path = unquote(parsed.path.decode())
-        self.request.query_string = (parsed.query or b'').decode()
-
-    def on_message_begin(self):
-        self.request = self.app.Request(self.app)
-        self.response = self.app.Response(self.app)
-
-    def on_message_complete(self):
-        self.request.method = self.parser.get_method().decode().upper()
-        task = self.app.loop.create_task(self.app(self.request, self.response))
-        task.add_done_callback(self.write)
-
-    # May or may not have "future" as arg.
-    def write(self, *args):
-        # Appends bytes for performances.
-        payload = b'HTTP/1.1 %a %b\r\n' % (
-            self.response.status.value, self.response.status.phrase.encode())
-        if not isinstance(self.response.body, bytes):
-            self.response.body = str(self.response.body).encode()
-        # https://tools.ietf.org/html/rfc7230#section-3.3.2 :scream:
-        bodyless = (self.response.status in self._BODYLESS_STATUSES or
-                    (hasattr(self, 'request') and
-                     self.request.method in self._BODYLESS_METHODS))
-        if 'Content-Length' not in self.response.headers and not bodyless:
-            length = len(self.response.body)
-            self.response.headers['Content-Length'] = length
-        if self.response._cookies:
-            # https://tools.ietf.org/html/rfc7230#page-23
-            for cookie in self.response.cookies.values():
-                payload += b'Set-Cookie: %b\r\n' % str(cookie).encode()
-        for key, value in self.response.headers.items():
-            payload += b'%b: %b\r\n' % (key.encode(), str(value).encode())
-        payload += b'\r\n'
-        if self.response.body and not bodyless:
-            payload += self.response.body
-        self.writer.write(payload)
-        if not self.parser.should_keep_alive():
-            self.writer.close()
-
-
+            
 Route = namedtuple('Route', ['payload', 'vars'])
 
 
@@ -402,6 +322,7 @@ class Roll:
     def __init__(self):
         self.routes = self.Routes()
         self.hooks = {}
+        self._protocol = None
 
     async def startup(self):
         await self.hook('startup')
@@ -442,7 +363,9 @@ class Roll:
             response.body = str(e)
 
     def factory(self):
-        return self.Protocol(self)
+        if self._protocol is None:
+            self._protocol = self.Protocol(self)
+        return self._protocol
 
     def route(self, path: str, methods: list=None, **extras: dict):
         if methods is None:
@@ -471,3 +394,46 @@ class Roll:
         except KeyError:
             # Nobody registered to this event, let's roll anyway.
             pass
+
+
+class WSRoll(Roll):
+
+    Protocol = WSProtocol
+
+    def __init__(self):
+        super(WSRoll, self).__init__()
+        self.websockets = set()
+
+    def route(self, path: str, websocket: bool=False,
+              subprotocols: list=None, methods: list=None, **extras: dict):
+
+        if not websocket:
+            return super(WSRoll, self).route(path, methods=methods, **extras)
+
+        if methods and methods != ['GET']:
+            raise RuntimeError('Websockets can only handshake on GET.')
+            
+        extras['is_websocket'] = websocket
+        def ws_wrapper(func):
+            async def websocket_handler(request, response, **params):
+                protocol = request.app._protocol
+                ws = await protocol.websocket_handshake(request, subprotocols)
+                fut = ensure_future(func(request, ws, **params))
+                self.websockets.add(fut)
+                try:
+                    await fut
+                except (CancelledError, ConnectionClosed):
+                    # Something went wrong, please do something !
+                    print(f'Socket @ {path} went sour !')
+                finally:
+                    # Gracefully close the websockets, please.
+                    self.websockets.remove(fut)
+                    await ws.close()
+
+            payload = {'GET':  websocket_handler}
+            payload.update(extras)
+            self.routes.add(path, **payload)
+
+        return ws_wrapper
+        
+

--- a/roll/__init__.py
+++ b/roll/__init__.py
@@ -192,7 +192,7 @@ class Request(dict):
         'method', 'body', 'headers', 'route', '_cookies', '_form', '_files',
     )
 
-    def __init__(self, app, transport):
+    def __init__(self, app, transport=None):
         self.app = app
         self.transport = transport
         self.headers = {}
@@ -412,7 +412,7 @@ class WSRoll(Roll):
 
         if methods and methods != ['GET']:
             raise RuntimeError('Websockets can only handshake on GET.')
-            
+
         extras['is_websocket'] = websocket
         if subprotocols:
             subprotocols = frozenset(subprotocols)  # Set in stone.

--- a/roll/__init__.py
+++ b/roll/__init__.py
@@ -433,7 +433,8 @@ class WSRoll(Roll):
                     await fut
                 except (asyncio.CancelledError, ConnectionClosed):
                     # Something went wrong on the websocket !
-                    print(f'Socket @ {path} went sour !')
+                    # We should log something
+                    print('Socket @ {} went sour !'.format(path))
                 except:
                     # Should we break the pipe ?
                     # If so, we close the transport writer here.

--- a/roll/__init__.py
+++ b/roll/__init__.py
@@ -8,7 +8,7 @@ If you do not understand why something is not working as expected,
 please submit an issue (or even better a pull-request with at least
 a test failing): https://github.com/pyrates/roll/issues/new
 """
-from asyncio import ensure_future, CancelledError
+from asyncio import ensure_future, CancelledError, gather
 from collections import namedtuple
 from http import HTTPStatus
 from io import BytesIO
@@ -411,7 +411,7 @@ class WSRoll(Roll):
             return super(WSRoll, self).route(path, methods=methods, **extras)
 
         if methods and methods != ['GET']:
-            raise RuntimeError('Websockets can only handshake on GET.')
+            raise RuntimeError('Websockets can only handshake on GET')
 
         extras['is_websocket'] = websocket
         if subprotocols:
@@ -435,11 +435,10 @@ class WSRoll(Roll):
                     # Gracefully close the websockets, please.
                     self.websockets.remove((fut, ws))
                     await ws.close()
+                    await fut.cancel()
 
             payload = {'GET':  websocket_handler}
             payload.update(extras)
             self.routes.add(path, **payload)
 
         return ws_wrapper
-        
-

--- a/roll/__init__.py
+++ b/roll/__init__.py
@@ -402,7 +402,7 @@ class WSRoll(Roll):
 
     def __init__(self):
         super(WSRoll, self).__init__()
-        self.websockets = set()
+        self.websockets = set()  # set of 2 items tuple, (task, websocket)
 
     def route(self, path: str, websocket: bool=False,
               subprotocols: list=None, methods: list=None, **extras: dict):
@@ -421,7 +421,7 @@ class WSRoll(Roll):
                 protocol = request.transport.get_protocol()
                 ws = await protocol.websocket_handshake(request, subprotocols)
                 fut = ensure_future(func(request, ws, **params))
-                self.websockets.add(fut)
+                self.websockets.add((fut, ws))
                 try:
                     await fut
                 except (CancelledError, ConnectionClosed):
@@ -429,12 +429,11 @@ class WSRoll(Roll):
                     print(f'Socket @ {path} went sour !')
                 except:
                     # Something very wrong happened.
-                    # Probably serverside.
-                    import pdb
-                    pdb.set_trace()
+                    # Probably serverside. Do something ?
+                    pass
                 finally:
                     # Gracefully close the websockets, please.
-                    self.websockets.remove(fut)
+                    self.websockets.remove((fut, ws))
                     await ws.close()
 
             payload = {'GET':  websocket_handler}

--- a/roll/extensions.py
+++ b/roll/extensions.py
@@ -29,7 +29,7 @@ def logger(app, level=logging.DEBUG, handler=None):
     handler = handler or logging.StreamHandler()
 
     @app.listen('request')
-    async def log_request(request):
+    async def log_request(request, response):
         logger.info('%s %s', request.method, request.url.decode())
 
     @app.listen('startup')
@@ -44,7 +44,7 @@ def logger(app, level=logging.DEBUG, handler=None):
 def options(app):
 
     @app.listen('request')
-    async def handle_options(request):
+    async def handle_options(request, response):
         # Shortcut the request handling for OPTIONS requests.
         return request.method == 'OPTIONS'
 
@@ -58,7 +58,7 @@ def content_negociation(app):
                  'content_negociation extension.')
 
     @app.listen('request')
-    async def reject_unacceptable_requests(request):
+    async def reject_unacceptable_requests(request, response):
         accept = request.headers.get('ACCEPT')
         accepts = request.route.payload['accepts']
         if accept is None or get_best_match(accept, accepts) is None:

--- a/roll/extensions.py
+++ b/roll/extensions.py
@@ -29,7 +29,7 @@ def logger(app, level=logging.DEBUG, handler=None):
     handler = handler or logging.StreamHandler()
 
     @app.listen('request')
-    async def log_request(request, response):
+    async def log_request(request):
         logger.info('%s %s', request.method, request.url.decode())
 
     @app.listen('startup')
@@ -44,7 +44,7 @@ def logger(app, level=logging.DEBUG, handler=None):
 def options(app):
 
     @app.listen('request')
-    async def handle_options(request, response):
+    async def handle_options(request):
         # Shortcut the request handling for OPTIONS requests.
         return request.method == 'OPTIONS'
 
@@ -58,7 +58,7 @@ def content_negociation(app):
                  'content_negociation extension.')
 
     @app.listen('request')
-    async def reject_unacceptable_requests(request, response):
+    async def reject_unacceptable_requests(request):
         accept = request.headers.get('ACCEPT')
         accepts = request.route.payload['accepts']
         if accept is None or get_best_match(accept, accepts) is None:

--- a/roll/protocols.py
+++ b/roll/protocols.py
@@ -124,7 +124,6 @@ class WSProtocol(Protocol):
 
     def write(self, *args):
         if self.websocket is not None:
-            # websocket requests do not write a response
             self.writer.close()
         else:
             super().write(*args)
@@ -133,7 +132,7 @@ class WSProtocol(Protocol):
         self.request = self.app.Request(self.app, self.writer)
         self.response = self.app.Response(self.app)
             
-    async def websocket_handshake(self, request, subprotocols: set=None):
+    def websocket_handshake(self, request, subprotocols: set=None):
         """Websocket handshake, handled by `websockets`
         """
         headers = []

--- a/roll/protocols.py
+++ b/roll/protocols.py
@@ -52,9 +52,6 @@ class Protocol(asyncio.Protocol):
         self.request.path = unquote(parsed.path.decode())
         self.request.query_string = (parsed.query or b'').decode()
 
-    def on_headers_complete(self):
-        self.request.transport = self.writer
-
     def on_message_begin(self):
         self.request = self.app.Request(self.app, self.writer)
         self.response = self.app.Response(self.app)

--- a/roll/protocols.py
+++ b/roll/protocols.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+
+import asyncio
+from http import HTTPStatus
+from urllib.parse import unquote
+from httptools import (
+    HttpParserUpgrade, HttpParserError, HttpRequestParser, parse_url)
+from websockets import handshake, WebSocketCommonProtocol, InvalidHandshake
+from websockets import ConnectionClosed  # exposed for convenience
+
+
+class Protocol(asyncio.Protocol):
+    """Responsible of parsing the request and writing the response."""
+
+    __slots__ = ('app', 'request', 'parser', 'response', 'writer')
+    _BODYLESS_METHODS = ('HEAD', 'CONNECT')
+    _BODYLESS_STATUSES = (HTTPStatus.CONTINUE, HTTPStatus.SWITCHING_PROTOCOLS,
+                          HTTPStatus.PROCESSING, HTTPStatus.NO_CONTENT,
+                          HTTPStatus.NOT_MODIFIED)
+    RequestParser = HttpRequestParser
+
+    def __init__(self, app):
+        self.app = app
+        self.parser = self.RequestParser(self)
+
+    def data_received(self, data: bytes):
+        try:
+            self.parser.feed_data(data)
+        except HttpParserError:
+            # If the parsing failed before on_message_begin, we don't have a
+            # response.
+            self.response = self.app.Response(self.app)
+            self.response.status = HTTPStatus.BAD_REQUEST
+            self.response.body = b'Unparsable request'
+            self.write()
+
+    def connection_made(self, transport):
+        self.writer = transport
+
+    # All on_xxx methods are in use by httptools parser.
+    # See https://github.com/MagicStack/httptools#apis
+    def on_header(self, name: bytes, value: bytes):
+        self.request.headers[name.decode().upper()] = value.decode()
+
+    def on_body(self, body: bytes):
+        # FIXME do not put all body in RAM blindly.
+        self.request.body += body
+
+    def on_url(self, url: bytes):
+        self.request.url = url
+        parsed = parse_url(url)
+        self.request.path = unquote(parsed.path.decode())
+        self.request.query_string = (parsed.query or b'').decode()
+
+    def on_message_begin(self):
+        self.request = self.app.Request(self.app)
+        self.response = self.app.Response(self.app)
+
+    def on_message_complete(self):
+        self.request.method = self.parser.get_method().decode().upper()
+        task = self.app.loop.create_task(self.app(self.request, self.response))
+        task.add_done_callback(self.write)
+
+    # May or may not have "future" as arg.
+    def write(self, *args):
+        # Appends bytes for performances.
+        payload = b'HTTP/1.1 %a %b\r\n' % (
+            self.response.status.value, self.response.status.phrase.encode())
+        if not isinstance(self.response.body, bytes):
+            self.response.body = str(self.response.body).encode()
+        # https://tools.ietf.org/html/rfc7230#section-3.3.2 :scream:
+        bodyless = (self.response.status in self._BODYLESS_STATUSES or
+                    (hasattr(self, 'request') and
+                     self.request.method in self._BODYLESS_METHODS))
+        if 'Content-Length' not in self.response.headers and not bodyless:
+            length = len(self.response.body)
+            self.response.headers['Content-Length'] = length
+        if self.response._cookies:
+            # https://tools.ietf.org/html/rfc7230#page-23
+            for cookie in self.response.cookies.values():
+                payload += b'Set-Cookie: %b\r\n' % str(cookie).encode()
+        for key, value in self.response.headers.items():
+            payload += b'%b: %b\r\n' % (key.encode(), str(value).encode())
+        payload += b'\r\n'
+        if self.response.body and not bodyless:
+            payload += self.response.body
+        self.writer.write(payload)
+        if not self.parser.should_keep_alive():
+            self.writer.close()
+
+
+class WSProtocol(Protocol):
+    """Websocket protocol.
+    """
+
+    def __init__(self, *args, websocket_timeout=10,
+                 websocket_max_size=2 ** 20,  # 1 megabytes
+                 websocket_max_queue=64,
+                 websocket_read_limit=2 ** 16,
+                 websocket_write_limit=2 ** 16, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.websocket = None
+        self.websocket_timeout = websocket_timeout
+        self.websocket_max_size = websocket_max_size
+        self.websocket_max_queue = websocket_max_queue
+        self.websocket_read_limit = websocket_read_limit
+        self.websocket_write_limit = websocket_write_limit
+
+    def connection_lost(self, exc):
+        if self.websocket is not None:
+            self.websocket.connection_lost(exc)
+        super().connection_lost(exc)
+
+    def data_received(self, data):
+        if self.websocket is not None:
+            # pass the data to the websocket protocol
+            self.websocket.data_received(data)
+        else:
+            try:
+                super().data_received(data)
+            except HttpParserUpgrade:
+                # Upgrade request
+                pass
+
+    def write(self, *args):
+        if self.websocket is not None:
+            # websocket requests do not write a response
+            self.writer.close()
+        else:
+            super().write(*args)
+
+    async def websocket_handshake(self, request, subprotocols=None):
+        """Websocket handshake, handled by `websockets`
+        """
+        headers = []
+
+        def get_header(k):
+            return request.headers.get(k.upper(), '')
+
+        def set_header(k, v):
+            headers.append((k.upper(), v))
+
+        try:
+            key = handshake.check_request(get_header)
+            handshake.build_response(set_header, key)
+        except InvalidHandshake:
+            raise RuntimeError('Invalid websocket request')
+
+        subprotocol = None
+        if subprotocols and 'Sec-Websocket-Protocol' in request.headers:
+            # select a subprotocol
+            client_subprotocols = [
+                p.strip() for p in
+                get_header('Sec-Websocket-Protocol').split(',')]
+
+            for p in client_subprotocols:
+                if p in subprotocols:
+                    subprotocol = p
+                    set_header('Sec-Websocket-Protocol', subprotocol)
+                    break
+
+        # write the 101 response back to the client
+        rv = b'HTTP/1.1 101 Switching Protocols\r\n'
+        for k, v in headers:
+            rv += k.encode('utf-8') + b': ' + v.encode('utf-8') + b'\r\n'
+        rv += b'\r\n'
+        self.writer.write(rv)
+
+        # hook up the websocket protocol
+        self.websocket = WebSocketCommonProtocol(
+            timeout=self.websocket_timeout,
+            max_size=self.websocket_max_size,
+            max_queue=self.websocket_max_queue,
+            read_limit=self.websocket_read_limit,
+            write_limit=self.websocket_write_limit
+        )
+        self.websocket.subprotocol = subprotocol
+        self.websocket.connection_made(self.writer)
+        self.websocket.connection_open()
+        return self.websocket

--- a/roll/protocols.py
+++ b/roll/protocols.py
@@ -32,7 +32,7 @@ class Protocol(asyncio.Protocol):
         except HttpParserError:
             # If the parsing failed before on_message_begin, we don't have a
             # response.
-            self.response = self.app.Response(self.app, self.writer)
+            self.response = self.app.Response(self.app)
             self.response.status = HTTPStatus.BAD_REQUEST
             self.response.body = b'Unparsable request'
             self.write()
@@ -53,7 +53,7 @@ class Protocol(asyncio.Protocol):
         self.request.query_string = (parsed.query or b'').decode()
 
     def on_message_begin(self):
-        self.request = self.app.Request(self.app, self.writer)
+        self.request = self.app.Request(self.app)
         self.response = self.app.Response(self.app)
 
     def on_message_complete(self):
@@ -129,6 +129,10 @@ class WSProtocol(Protocol):
         else:
             super().write(*args)
 
+    def on_message_begin(self):
+        self.request = self.app.Request(self.app, self.writer)
+        self.response = self.app.Response(self.app)
+            
     async def websocket_handshake(self, request, subprotocols: set=None):
         """Websocket handshake, handled by `websockets`
         """

--- a/roll/testing.py
+++ b/roll/testing.py
@@ -1,12 +1,12 @@
+# -*- coding: utf-8 -*-
+
 import json
-import asyncio
 import mimetypes
 import pytest
 
 from io import BytesIO
 from urllib.parse import urlencode
 from uuid import uuid4
-
 
 
 def encode_multipart(data, charset='utf-8'):
@@ -134,15 +134,14 @@ class Client:
             body = body.encode()
         self.protocol = self.app.factory()
         self.protocol.connection_made(Transport())
-        self.protocol.on_message_begin()
-        self.protocol.on_url(path.encode())
+        self.protocol.incoming.on_message_begin()
+        self.protocol.incoming.on_url(path.encode())
         self.protocol.request.body = body
         self.protocol.request.method = method
         for key, value in headers.items():
-            self.protocol.on_header(key.encode(), value.encode())
-        handler, params = self.app.lookup(self.protocol.request)
-        response = await self.app(self.protocol.request, handler, params)
-        self.protocol.write(response)
+            self.protocol.incoming.on_header(key.encode(), value.encode())
+        response = await self.app(self.protocol.request)
+        self.protocol.reply(response)
         return response
 
     async def get(self, path, **kwargs):

--- a/roll/testing.py
+++ b/roll/testing.py
@@ -193,13 +193,14 @@ class LiveClient:
         self.app = app
         self.loop = loop
         self.url = None
-
+ 
     def start(self):
         port = unused_port()
         self.app.loop.run_until_complete(self.app.startup())
         self.server = self.app.loop.run_until_complete(
             self.loop.create_server(self.app.factory, '127.0.0.1', port))
         self.url = 'http://127.0.0.1:{port}'.format(port=port)
+        self.wsl = 'ws://127.0.0.1:{port}'.format(port=port)
 
     def stop(self):
         self.server.close()

--- a/roll/websockets.py
+++ b/roll/websockets.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+
+import asyncio
+import types
+from functools import wraps
+from roll.protocols import Context
+from urllib.parse import unquote
+from httptools import HttpParserUpgrade
+from websockets import handshake, WebSocketCommonProtocol, InvalidHandshake
+from websockets import ConnectionClosed  # exposed for convenience
+
+
+class WebsocketContext(Context):
+
+    websocket_timeout = 5
+    websocket_max_size = 2 ** 20  # 1 megabytes
+    websocket_max_queue = 16
+    websocket_read_limit = 2 ** 16
+    websocket_write_limit = 2 ** 16
+    
+    __slots__ = ('websocket',)
+
+    def __init__(self, app, writer, parser):
+        super().__init__(app, writer, parser)
+
+    def create_websocket(self, subprotocol):
+        self.websocket = WebSocketCommonProtocol(
+            timeout=self.websocket_timeout,
+            max_size=self.websocket_max_size,
+            max_queue=self.websocket_max_queue,
+            read_limit=self.websocket_read_limit,
+            write_limit=self.websocket_write_limit
+        )
+        self.websocket.subprotocol = subprotocol
+        self.websocket.connection_made(self.writer)
+        self.websocket.connection_open()
+        return self.websocket
+
+    def connection_lost(self, exc):
+        self.websocket.connection_lost(exc)
+
+    def data_received(self, data):
+        # Received data. We refuse the data if the websocket is
+        # already closed. If the websocket is closing, this data
+        # might be part of the closing handshake (closing frame)
+        if self.websocket.state != 3:  # not closed
+            self.websocket.data_received(data)
+        else:
+            # The websocket is closed and we still get data for it
+            # This is an unexpected problem. Let's do nothing
+            # about it
+            pass
+
+    def write(self, *args):
+        self.writer.close()
+
+
+def websocket_handshake(request, subprotocols: set=None):
+    """Websocket handshake, handled by `websockets`
+    """
+    headers = []
+    
+    def get_header(k):
+        return request.headers.get(k.upper(), '')
+
+    def set_header(k, v):
+        headers.append((k, v))
+
+    try:
+        key = handshake.check_request(get_header)
+        handshake.build_response(set_header, key)
+    except InvalidHandshake:
+        raise RuntimeError('Invalid websocket request')
+
+    subprotocol = None
+    ws_protocol = get_header('Sec-Websocket-Protocol')
+    if subprotocols and ws_protocol:
+        # select a subprotocol
+        client_subprotocols = tuple(
+            (p.strip() for p in ws_protocol.split(',')))
+        for p in client_subprotocols:
+            if p in subprotocols:
+                subprotocol = p
+                set_header('Sec-Websocket-Protocol', subprotocol)
+                break
+
+    # write the 101 response back to the client
+    rv = b'HTTP/1.1 101 Switching Protocols\r\n'
+    for k, v in headers:
+        rv += k.encode('utf-8') + b': ' + v.encode('utf-8') + b'\r\n'
+    rv += b'\r\n'
+    request.context.write(rv)
+
+    # hook up the websocket protocol and new context
+    ws_context = WebsocketContext(
+        request.app, request.context.writer, request.context.parser)
+    request.set_context(ws_context)
+    return ws_context.create_websocket(subprotocol)
+
+
+def websocket(app, path, subprotocols: list=None, **extras: dict):
+
+    if subprotocols is not None:
+        subprotocols = frozenset(subprotocols)
+
+    def websocket_wrapper(handler):
+
+        async def websocket_handler(request, _, **params):
+            ws = websocket_handshake(request, subprotocols)
+            fut = asyncio.ensure_future(
+                handler(request, ws, **params), loop=app.loop)
+            app.storage['websockets'].add((fut, ws))
+            try:
+                await fut
+            except ConnectionClosed:
+                # The client closed the connection.
+                # We cancel the future to be sure it's in order.
+                fut.cancel()
+                await ws.close(1002, 'Connection closed untimely.')
+            except asyncio.CancelledError:
+                # The websocket task was cancelled
+                # We need to warn the client.
+                await ws.close(1001, 'Handler cancelled.')
+            except Exception as exc:
+                # A more serious error happened.
+                # The websocket handler was untimely terminated
+                # by an unwarranted exception. Warn the client.
+                await ws.close(1011, 'Handler died prematurely.')
+                raise
+            else:
+                # The handler finished gracefully.
+                # We can close the socket in peace.
+                await ws.close()
+            finally:
+                # Whatever happened, the websocket fate has been
+                # sealed. We remove it from our watch.
+                app.storage['websockets'].discard((fut, ws))
+
+        payload = {'GET': websocket_handler}
+        payload.update(extras)
+        app.routes.add(path, **payload)
+        return handler
+
+    return websocket_wrapper
+
+
+def websockets(app):
+    app.storage['websockets'] = set()
+    app.websocket = types.MethodType(websocket, app)

--- a/roll/websockets.txt
+++ b/roll/websockets.txt
@@ -1,0 +1,69 @@
+Websockets inner and outer workings
+===================================
+
+
+Valid closing codes for endpoints
+---------------------------------
+
+Endpoints MAY use the following pre-defined status codes when sending
+a Close frame.
+
+
+   1000
+
+      1000 indicates a normal closure, meaning that the purpose for
+      which the connection was established has been fulfilled.
+
+   1001
+
+      1001 indicates that an endpoint is "going away", such as a server
+      going down or a browser having navigated away from a page.
+
+   1002
+
+      1002 indicates that an endpoint is terminating the connection due
+      to a protocol error.
+
+   1003
+
+      1003 indicates that an endpoint is terminating the connection
+      because it has received a type of data it cannot accept (e.g., an
+      endpoint that understands only text data MAY send this if it
+      receives a binary message).
+
+   1007
+
+      1007 indicates that an endpoint is terminating the connection
+      because it has received data within a message that was not
+      consistent with the type of the message (e.g., non-UTF-8 [RFC3629]
+      data within a text message).
+
+   1008
+
+      1008 indicates that an endpoint is terminating the connection
+      because it has received a message that violates its policy.  This
+      is a generic status code that can be returned when there is no
+      other more suitable status code (e.g., 1003 or 1009) or if there
+      is a need to hide specific details about the policy.
+
+   1009
+
+      1009 indicates that an endpoint is terminating the connection
+      because it has received a message that is too big for it to
+      process.
+
+   1010
+
+      1010 indicates that an endpoint (client) is terminating the
+      connection because it has expected the server to negotiate one or
+      more extension, but the server didn't return them in the response
+      message of the WebSocket handshake.  The list of extensions that
+      are needed SHOULD appear in the /reason/ part of the Close frame.
+      Note that this status code is not used by the server, because it
+      can fail the WebSocket handshake instead.
+
+   1011
+
+      1011 indicates that a server is terminating the connection because
+      it encountered an unexpected condition that prevented it from
+      fulfilling the request.

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -9,9 +9,9 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
-def protocol(app, event_loop):
+def protocol(app):
     protocol = Protocol(app)
-    protocol.connection_made(Transport(protocol, event_loop))
+    protocol.connection_made(Transport())
     return protocol
 
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -9,9 +9,9 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
-def protocol(app):
+def protocol(app, event_loop):
     protocol = Protocol(app)
-    protocol.connection_made(Transport())
+    protocol.connection_made(Transport(protocol, event_loop))
     return protocol
 
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -143,37 +143,37 @@ async def test_request_host_shortcut(protocol):
 async def test_invalid_request(protocol):
     protocol.data_received(
         b'INVALID HTTP/1.22\r\n')
-    assert protocol.response.status == HTTPStatus.BAD_REQUEST
+    assert protocol.outgoing.response.status == HTTPStatus.BAD_REQUEST
 
 
 async def test_query_get_should_return_value(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=value')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=value')
     assert protocol.request.query.get('key') == 'value'
 
 
 async def test_query_get_should_return_first_value_if_multiple(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=value&key=value2')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=value&key=value2')
     assert protocol.request.query.get('key') == 'value'
 
 
 async def test_query_get_should_raise_if_no_key_and_no_default(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=value')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=value')
     with pytest.raises(HttpError):
         protocol.request.query.get('other')
 
 
 async def test_query_getlist_should_return_list_of_values(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=value&key=value2')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=value&key=value2')
     assert protocol.request.query.list('key') == ['value', 'value2']
 
 
 async def test_query_get_should_return_default_if_key_is_missing(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=value')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=value')
     assert protocol.request.query.get('other', None) is None
     assert protocol.request.query.get('other', 'default') == 'default'
 
@@ -195,98 +195,98 @@ async def test_query_get_should_return_default_if_key_is_missing(protocol):
     (b'NULL', None),
 ])
 async def test_query_bool_should_cast_to_boolean(input, expected, protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=' + input)
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=' + input)
     assert protocol.request.query.bool('key') == expected
 
 
 async def test_query_bool_should_return_default(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=1')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=1')
     assert protocol.request.query.bool('other', default=False) is False
 
 
 async def test_query_bool_should_raise_if_not_castable(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=one')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=one')
     with pytest.raises(HttpError):
         assert protocol.request.query.bool('key')
 
 
 async def test_query_bool_should_raise_if_not_key_and_no_default(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=one')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=one')
     with pytest.raises(HttpError):
         assert protocol.request.query.bool('other')
 
 
 async def test_query_bool_should_return_default_if_key_not_present(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=one')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=one')
     assert protocol.request.query.bool('other', default=False) is False
 
 
 async def test_query_int_should_cast_to_int(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=22')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=22')
     assert protocol.request.query.int('key') == 22
 
 
 async def test_query_int_should_return_default(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=1')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=1')
     assert protocol.request.query.int('other', default=22) == 22
 
 
 async def test_query_int_should_raise_if_not_castable(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=one')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=one')
     with pytest.raises(HttpError):
         assert protocol.request.query.int('key')
 
 
 async def test_query_int_should_raise_if_not_key_and_no_default(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=one')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=one')
     with pytest.raises(HttpError):
         assert protocol.request.query.int('other')
 
 
 async def test_query_int_should_return_default_if_key_not_present(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=one')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=one')
     assert protocol.request.query.int('other', default=22) == 22
 
 
 async def test_query_float_should_cast_to_float(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=2.234')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=2.234')
     assert protocol.request.query.float('key') == 2.234
 
 
 async def test_query_float_should_return_default(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=1')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=1')
     assert protocol.request.query.float('other', default=2.234) == 2.234
 
 
 async def test_query_float_should_raise_if_not_castable(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=one')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=one')
     with pytest.raises(HttpError):
         assert protocol.request.query.float('key')
 
 
 async def test_query_float_should_raise_if_not_key_and_no_default(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=one')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=one')
     with pytest.raises(HttpError):
         assert protocol.request.query.float('other')
 
 
 async def test_query_float_should_return_default_if_key_not_present(protocol):
-    protocol.on_message_begin()
-    protocol.on_url(b'/?key=one')
+    protocol.incoming.on_message_begin()
+    protocol.incoming.on_url(b'/?key=one')
     assert protocol.request.query.float('other', default=2.234) == 2.234
 
 
@@ -355,7 +355,7 @@ async def test_request_get_unknown_cookie_key_raises_keyerror(protocol):
 
 
 async def test_can_store_arbitrary_keys_on_request():
-    request = Request(None)
+    request = Request(None, None)
     request['custom'] = 'value'
     assert 'custom' in request
     assert request['custom'] == 'value'

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -14,13 +14,13 @@ async def test_websocket_route(liveclient):
         assert ws.subprotocol is None
         ev.set()
 
-    body, response = await liveclient.query('get', '/ws', headers={
+    response = await liveclient.query('GET', '/ws', headers={
         'Upgrade': 'websocket',
         'Connection': 'upgrade',
         'Sec-WebSocket-Key': 'hojIvDoHedBucveephosh8==',
         'Sec-WebSocket-Version': '13'})
     assert ev.is_set()
-    assert response.status == 101
+    assert response.status_code == 101
 
     with pytest.raises(RuntimeError) as exc:
         @liveclient.app.route('/ws', websocket=True, methods=['POST'])
@@ -105,35 +105,35 @@ async def test_websocket_route_with_subprotocols(liveclient):
     async def handler(request, ws):
         results.append(ws.subprotocol)
 
-    body, response = await liveclient.query('get', '/ws', headers={
+    response = await liveclient.query('GET', '/ws', headers={
         'Upgrade': 'websocket',
         'Connection': 'upgrade',
         'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
         'Sec-WebSocket-Version': '13',
         'Sec-WebSocket-Protocol': 'bar'})
-    assert response.status == 101
+    assert response.status_code == 101
 
-    body, response = await liveclient.query('get', '/ws', headers={
+    response = await liveclient.query('GET', '/ws', headers={
         'Upgrade': 'websocket',
         'Connection': 'upgrade',
         'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
         'Sec-WebSocket-Version': '13',
         'Sec-WebSocket-Protocol': 'bar, foo'})
-    assert response.status == 101
+    assert response.status_code == 101
 
-    body, response = await liveclient.query('get', '/ws', headers={
+    response = await liveclient.query('GET', '/ws', headers={
         'Upgrade': 'websocket',
         'Connection': 'upgrade',
         'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
         'Sec-WebSocket-Version': '13',
         'Sec-WebSocket-Protocol': 'baz'})
-    assert response.status == 101
+    assert response.status_code == 101
 
-    body, response = await liveclient.query('get', '/ws', headers={
+    response = await liveclient.query('GET', '/ws', headers={
         'Upgrade': 'websocket',
         'Connection': 'upgrade',
         'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
         'Sec-WebSocket-Version': '13'})
-    assert response.status == 101
+    assert response.status_code == 101
 
     assert results == ['bar', 'bar', None, None]

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import asyncio
+
+
+@pytest.mark.asyncio
+async def test_websocket_route(wsclient, wsapp):
+    ev = asyncio.Event()
+
+    @wsapp.route('/ws', websocket=True)
+    async def handler(request, ws, **params):
+        assert ws.subprotocol is None
+        ev.set()
+
+    response = await wsclient.get('/ws', headers={
+        'Upgrade': 'websocket',
+        'Connection': 'upgrade',
+        'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+        'Sec-WebSocket-Version': '13'})
+    assert ev.is_set()
+
+
+    @wsapp.route('/ws', websocket=True, methods=['POST'])
+    async def handler(request, ws, **params):
+        assert ws.subprotocol is None
+        ev.set()

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -96,8 +96,10 @@ async def test_websocket_binary(liveclient):
     # Echo
     websocket = await websockets.connect(liveclient.wsl + '/bin')
     bdata = await websocket.recv()
-    await asyncio.wait_for(websocket.close(), 1)
+    await websocket.close_connection_task
     assert bdata == b'test'
+    assert websocket.close_reason == ''
+    assert websocket.state == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -2,6 +2,7 @@
 
 import pytest
 import asyncio
+import websockets
 
 
 @pytest.mark.asyncio
@@ -28,3 +29,56 @@ async def test_websocket_route(liveclient):
             ev.set()
 
     assert str(exc.value) == 'Websockets can only handshake on GET'
+
+
+@pytest.mark.asyncio
+async def test_websocket_communication(liveclient):
+
+    @liveclient.app.route('/echo', websocket=True)
+    async def echo(request, ws, **params):
+        async for message in ws:
+            await ws.send(message)
+
+    # Echo
+    websocket = await websockets.connect(liveclient.wsl + '/echo')
+    try:
+        for message in ('This', 'is', 'a', 'simple', 'test'):
+            await websocket.send(message)
+            echoed = await websocket.recv()
+            assert echoed == message
+    finally:
+        await websocket.close()
+
+    # Nothing sent, just close
+    websocket = await websockets.connect(liveclient.wsl + '/echo')
+    await websocket.close()
+
+
+@pytest.mark.asyncio
+async def test_websocket_broadcasting(liveclient):
+
+    @liveclient.app.route('/broadcast', websocket=True)
+    async def feed(request, ws, **params):
+        async for message in ws:
+            for (task, socket) in request.app.websockets:
+                if socket != ws:
+                    await socket.send(message)
+
+    # connecting
+    connected = []
+    for n in range(1, 6):
+        ws = await websockets.connect(liveclient.wsl + '/broadcast')
+        connected.append(ws)
+
+    # Broadcasting
+    for wid, ws in enumerate(connected, 1):
+        broadcast = 'this is a broadcast from {}'.format(wid)
+        await ws.send(broadcast)
+        for ows in connected:
+            if ows != ws:
+                message = await ows.recv()
+                assert message == broadcast
+
+    # Closing
+    for ws in connected:
+        await ws.close()

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -9,7 +9,7 @@ import websockets
 async def test_websocket_route(liveclient):
     ev = asyncio.Event()
 
-    @liveclient.app.route('/ws', websocket=True)
+    @liveclient.app.websocket('/ws')
     async def handler(request, ws, **params):
         assert ws.subprotocol is None
         ev.set()
@@ -22,19 +22,11 @@ async def test_websocket_route(liveclient):
     assert ev.is_set()
     assert response.status_code == 101
 
-    with pytest.raises(RuntimeError) as exc:
-        @liveclient.app.route('/ws', websocket=True, methods=['POST'])
-        async def handler(request, ws, **params):
-            assert ws.subprotocol is None
-            ev.set()
-
-    assert str(exc.value) == 'Websockets can only handshake on GET'
-
 
 @pytest.mark.asyncio
 async def test_websocket_communication(liveclient):
 
-    @liveclient.app.route('/echo', websocket=True)
+    @liveclient.app.websocket('/echo')
     async def echo(request, ws, **params):
         while True:
             message = await ws.recv()
@@ -58,13 +50,13 @@ async def test_websocket_communication(liveclient):
 @pytest.mark.asyncio
 async def test_websocket_broadcasting(liveclient):
 
-    @liveclient.app.route('/broadcast', websocket=True)
+    @liveclient.app.websocket('/broadcast')
     async def feed(request, ws, **params):
         while True:
             message = await ws.recv()
             await asyncio.wait([
                 socket.send(message) for (task, socket)
-                in request.app.websockets if socket != ws])
+                in request.app.storage['websockets'] if socket != ws])
 
     # connecting
     connected = []
@@ -89,7 +81,7 @@ async def test_websocket_broadcasting(liveclient):
 @pytest.mark.asyncio
 async def test_websocket_binary(liveclient):
 
-    @liveclient.app.route('/bin', websocket=True)
+    @liveclient.app.websocket('/bin')
     async def binary(request, ws, **params):
         await ws.send(b'test')
 
@@ -106,7 +98,7 @@ async def test_websocket_binary(liveclient):
 async def test_websocket_route_with_subprotocols(liveclient):
     results = []
 
-    @liveclient.app.route('/ws', websocket=True, subprotocols=['foo', 'bar'])
+    @liveclient.app.websocket('/ws', subprotocols=['foo', 'bar'])
     async def handler(request, ws):
         results.append(ws.subprotocol)
 

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -36,7 +36,8 @@ async def test_websocket_communication(liveclient):
 
     @liveclient.app.route('/echo', websocket=True)
     async def echo(request, ws, **params):
-        async for message in ws:
+        while True:
+            message = await ws.recv()
             await ws.send(message)
 
     # Echo
@@ -59,7 +60,8 @@ async def test_websocket_broadcasting(liveclient):
 
     @liveclient.app.route('/broadcast', websocket=True)
     async def feed(request, ws, **params):
-        async for message in ws:
+        while True:
+            message = await ws.recv()
             await asyncio.wait([
                 socket.send(message) for (task, socket)
                 in request.app.websockets if socket != ws])
@@ -93,8 +95,9 @@ async def test_websocket_binary(liveclient):
 
     # Echo
     websocket = await websockets.connect(liveclient.wsl + '/bin')
-    async for bdata in websocket:
-        assert bdata == b'test'
+    bdata = await websocket.recv()
+    await asyncio.wait_for(websocket.close(), 1)
+    assert bdata == b'test'
 
 
 @pytest.mark.asyncio

--- a/tests/test_websockets_failure.py
+++ b/tests/test_websockets_failure.py
@@ -8,7 +8,7 @@ import websockets
 @pytest.mark.asyncio
 async def test_websocket_failure(liveclient):
 
-    @liveclient.app.route('/failure', websocket=True)
+    @liveclient.app.websocket('/failure')
     async def failme(request, ws, **params):
         raise NotImplementedError('OUCH')
 
@@ -34,7 +34,7 @@ async def test_websocket_failure(liveclient):
 @pytest.mark.asyncio
 async def test_websocket_failure_intime(liveclient):
 
-    @liveclient.app.route('/failure', websocket=True)
+    @liveclient.app.websocket('/failure')
     async def failme(request, ws, **params):
         raise NotImplementedError('OUCH')
 
@@ -58,7 +58,7 @@ async def test_websocket_failure_intime(liveclient):
 @pytest.mark.asyncio
 async def test_websocket_failure_receive(liveclient):
 
-    @liveclient.app.route('/failure', websocket=True)
+    @liveclient.app.websocket('/failure')
     async def failme(request, ws, **params):
         raise NotImplementedError('OUCH')
 

--- a/tests/test_websockets_failure.py
+++ b/tests/test_websockets_failure.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 import asyncio
 import websockets
@@ -10,7 +12,64 @@ async def test_websocket_failure(liveclient):
     async def failme(request, ws, **params):
         raise NotImplementedError('OUCH')
 
-    # This should fail, it doesn't.
     websocket = await websockets.connect(liveclient.wsl + '/failure')
-    await websocket.send('test')
+
+    with pytest.raises(websockets.exceptions.ConnectionClosed) as exc:
+        # The client has 5 second (set in the protocol) before the
+        # closing handshake timeout and the brutal disconnection.
+        # We wait beyond the closing frame timeout :
+        await asyncio.sleep(6)
+
+        # No, we try sending while the closing frame timespan has expired
+        await websocket.send('first')
+
+    # No need to close here, the closing was unilateral, as we
+    # did not comply in time.
+    # We check the remains of the disowned client :
+    assert websocket.state == 3
+    assert websocket.close_code == 1011
+    assert websocket.close_reason == 'Handler died prematurely.'
+
+
+@pytest.mark.asyncio
+async def test_websocket_failure_intime(liveclient):
+
+    @liveclient.app.route('/failure', websocket=True)
+    async def failme(request, ws, **params):
+        raise NotImplementedError('OUCH')
+
+    websocket = await websockets.connect(liveclient.wsl + '/failure')
+    # Sent within the closing frame span messages will be ignored but
+    # won't create any error as the server is polite and awaits the
+    # closing frame to ends the interaction in a friendly manner.
+    await websocket.send('first')  
+
+    # The server is on hold, waiting for the closing handshake
+    # We provide it to be civilized.
     await websocket.close()
+    
+    # The websocket was closed with the error, but in a gentle way.
+    # No exception raised.
+    assert websocket.state == 3
+    assert websocket.close_code == 1011
+    assert websocket.close_reason == 'Handler died prematurely.'
+
+
+@pytest.mark.asyncio
+async def test_websocket_failure_receive(liveclient):
+
+    @liveclient.app.route('/failure', websocket=True)
+    async def failme(request, ws, **params):
+        raise NotImplementedError('OUCH')
+
+    websocket = await websockets.connect(liveclient.wsl + '/failure')
+    with pytest.raises(websockets.exceptions.ConnectionClosed) as exc:
+        # Receiving, on the other hand, will raise immediatly an
+        # error as the reader is closed. Only the writer is opened
+        # as we are expected to send back the closing frame.
+        await websocket.recv()
+
+    await websocket.close()
+    assert websocket.state == 3  # closing state
+    assert websocket.close_code == 1011
+    assert websocket.close_reason == 'Handler died prematurely.'

--- a/tests/test_websockets_failure.py
+++ b/tests/test_websockets_failure.py
@@ -1,0 +1,16 @@
+import pytest
+import asyncio
+import websockets
+
+
+@pytest.mark.asyncio
+async def test_websocket_failure(liveclient):
+
+    @liveclient.app.route('/failure', websocket=True)
+    async def failme(request, ws, **params):
+        raise NotImplementedError('OUCH')
+
+    # This should fail, it doesn't.
+    websocket = await websockets.connect(liveclient.wsl + '/failure')
+    await websocket.send('test')
+    await websocket.close()

--- a/ws_examples/test.py
+++ b/ws_examples/test.py
@@ -3,8 +3,8 @@
 import uuid
 import uvloop
 import asyncio
-from roll import Roll, WSRoll
-from roll import Response
+from roll import Roll, Response
+from roll.websockets import websockets, websocket
 from roll.extensions import logger, simple_server, traceback
 
 
@@ -18,34 +18,37 @@ class HTMLResponse(Response):
         self.body = body
 
         
-class Application(WSRoll):
+class Application(Roll):
     Response = HTMLResponse
 
-
+        
 app = Application()
 logger(app)
 traceback(app)
+websockets(app)
 
 
 @app.route('/')
-async def hello(request, response):
+async def hello(request, response_class):
+    response = response_class()
     response.html('Hello World !')
+    return response
 
 
-@app.route('/chat', websocket=True)
+@app.websocket('/chat', websocket=True)
 async def broadcast(request, ws, **params):
     wsid = str(uuid.uuid4())
     await ws.send(f'Welcome {wsid} !')
     async for message in ws:
-        for (task, socket) in request.app.websockets:
+        for (task, socket) in app.storage['websockets']:
             if socket != ws:
                 await socket.send('{}: {}'.format(wsid, message))
 
 
-@app.route('/fail', websocket=True)
+@app.websocket('/fail')
 async def failer(request, ws, **params):
     raise RuntimeError('TEST')
-                
+
 
 if __name__ == '__main__':
     simple_server(app)

--- a/ws_examples/test.py
+++ b/ws_examples/test.py
@@ -17,32 +17,23 @@ class HTMLResponse(Response):
         self.headers['Content-Type'] = 'plain/text'
         self.body = body
 
-
-class Basic(Roll):
-    Response = HTMLResponse
         
-
 class Application(WSRoll):
     Response = HTMLResponse
 
 
-base = Basic()
 app = Application()
 logger(app)
 traceback(app)
-logger(base)
-traceback(base)
 
 
-@base.route('/')
 @app.route('/')
 async def hello(request, response):
     response.html('Hello World !')
 
 
-@base.route('/feed')
-@app.route('/feed', websocket=True)
-async def feed(request, ws, **params):
+@app.route('/chat', websocket=True)
+async def broadcast(request, ws, **params):
     wsid = str(uuid.uuid4())
     await ws.send(f'Welcome {wsid} !')
     async for message in ws:
@@ -50,6 +41,11 @@ async def feed(request, ws, **params):
             if socket != ws:
                 await socket.send('{}: {}'.format(wsid, message))
 
+
+@app.route('/fail', websocket=True)
+async def failer(request, ws, **params):
+    raise RuntimeError('TEST')
+                
 
 if __name__ == '__main__':
     simple_server(app)

--- a/ws_examples/test.py
+++ b/ws_examples/test.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+import uvloop
+import asyncio
+from roll import WSRoll
+from roll import Response
+from roll.extensions import logger, simple_server, traceback
+
+
+asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+
+class HTMLResponse(Response):
+
+    def html(self, body):
+        self.headers['Content-Type'] = 'plain/text'
+        self.body = body
+
+
+class Application(WSRoll):
+    Response = HTMLResponse
+
+
+app = Application()
+logger(app)
+traceback(app)
+
+
+@app.route('/')
+async def hello(request, response):
+    response.html('Hello World !')
+
+
+@app.route('/feed', websocket=True)
+async def feed(request, ws, **params):
+    while True:
+        data = 'hello!'
+        print('Sending: ' + data)
+        await ws.send(data)
+        data = await ws.recv()
+        print('Received: ' + data)
+
+
+if __name__ == '__main__':
+    simple_server(app)

--- a/ws_examples/test.py
+++ b/ws_examples/test.py
@@ -29,10 +29,8 @@ websockets(app)
 
 
 @app.route('/')
-async def hello(request, response_class):
-    response = response_class()
+async def hello(request, response):
     response.html('Hello World !')
-    return response
 
 
 @app.websocket('/chat', websocket=True)

--- a/ws_examples/test.py
+++ b/ws_examples/test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import uuid
 import uvloop
 import asyncio
 from roll import WSRoll
@@ -33,12 +34,12 @@ async def hello(request, response):
 
 @app.route('/feed', websocket=True)
 async def feed(request, ws, **params):
-    while True:
-        data = 'hello!'
-        print('Sending: ' + data)
-        await ws.send(data)
-        data = await ws.recv()
-        print('Received: ' + data)
+    wsid = str(uuid.uuid4())
+    await ws.send(f'Welcome {wsid} !')
+    async for message in ws:
+        for (task, socket) in request.app.websockets:
+            if socket != ws:
+                await socket.send('{}: {}'.format(wsid, message))
 
 
 if __name__ == '__main__':

--- a/ws_examples/test.py
+++ b/ws_examples/test.py
@@ -3,7 +3,7 @@
 import uuid
 import uvloop
 import asyncio
-from roll import WSRoll
+from roll import Roll, WSRoll
 from roll import Response
 from roll.extensions import logger, simple_server, traceback
 
@@ -18,20 +18,29 @@ class HTMLResponse(Response):
         self.body = body
 
 
+class Basic(Roll):
+    Response = HTMLResponse
+        
+
 class Application(WSRoll):
     Response = HTMLResponse
 
 
+base = Basic()
 app = Application()
 logger(app)
 traceback(app)
+logger(base)
+traceback(base)
 
 
+@base.route('/')
 @app.route('/')
 async def hello(request, response):
     response.html('Hello World !')
 
 
+@base.route('/feed')
 @app.route('/feed', websocket=True)
 async def feed(request, ws, **params):
     wsid = str(uuid.uuid4())

--- a/ws_examples/websocket.html
+++ b/ws_examples/websocket.html
@@ -16,7 +16,7 @@
                 message.appendChild(content);
                 board.appendChild(message);
 	  }
-	  var ws = new WebSocket('ws://localhost:3579/chat);
+	  var ws = new WebSocket('ws://localhost:3579/chat');
           ws.onmessage = function (event) {
                 addMessage('Received <= ' + event.data);
           };

--- a/ws_examples/websocket.html
+++ b/ws_examples/websocket.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Chat</title>
+    </head>
+    <body>
+        <input id="message" type="text" />
+        <button onclick="sendMe()">Send</button>
+	<ul id="board">
+	</ul>
+        <script>	  
+	  function addMessage(text) {
+	        board = document.getElementById('board');
+                message = document.createElement('li'),
+                content = document.createTextNode(text);
+                message.appendChild(content);
+                board.appendChild(message);
+	  }
+	  var ws = new WebSocket('ws://localhost:3579/feed');
+          ws.onmessage = function (event) {
+                addMessage('Received <= ' + event.data);
+          };
+          function sendMe() {
+                let myinput = document.getElementById('message');
+                let message = myinput.value; 
+                ws.send(message);
+	        addMessage('Sent => ' + message)
+	        myinput.value = '';
+          }
+        </script>
+    </body>
+</html>

--- a/ws_examples/websocket.html
+++ b/ws_examples/websocket.html
@@ -16,7 +16,7 @@
                 message.appendChild(content);
                 board.appendChild(message);
 	  }
-	  var ws = new WebSocket('ws://localhost:3579/feed');
+	  var ws = new WebSocket('ws://localhost:3579/chat);
           ws.onmessage = function (event) {
                 addMessage('Received <= ' + event.data);
           };


### PR DESCRIPTION
Here is a first roughly functional draft of the idea we first discussed in the websocket pull-request.
Basically, my idea is for the protocol to delegate the IO to a pair of incoming/outgoing handlers.
They can be hot-switched when needed, as I do here for the websocket.

Additionnally, i implemented the websockets as a full extension, to show how it can be interconnected.

Furthermore, I main have gone a step too far by making the request non-tied to the protocol-outgoing part but as an object that can be passed alone. This was merely to play with the idea. This breaks all the tests, expect the websockets one.

Please, let me know what you think of this first attempt and how your vision of the solution would be.