### PR TITLE
Do not write on a closed transport

### DIFF
--- a/roll/__init__.py
+++ b/roll/__init__.py
@@ -523,9 +523,14 @@ class HTTPProtocol(asyncio.Protocol):
             # Request has been aborted, thus socket as been closed, thus
             # transport has been closed?
             return
-        self.transport.write(payload)
-        if not self.parser.should_keep_alive():
-            self.transport.close()
+        try:
+            self.transport.write(payload)
+        except RuntimeError:  # transport may still be closed during write.
+            # TODO: Pass into error hook when write is async.
+            pass
+        else:
+            if not self.parser.should_keep_alive():
+                self.transport.close()
 
 
 Route = namedtuple('Route', ['payload', 'vars'])

--- a/roll/__init__.py
+++ b/roll/__init__.py
@@ -519,6 +519,10 @@ class HTTPProtocol(asyncio.Protocol):
         payload += b'\r\n'
         if self.response.body and not bodyless:
             payload += self.response.body
+        if self.transport.is_closing():
+            # Request has been aborted, thus socket as been closed, thus
+            # transport has been closed?
+            return
         self.transport.write(payload)
         if not self.parser.should_keep_alive():
             self.transport.close()


### PR DESCRIPTION
Open questions:

- should we try to write and catch RuntimeError instead?
- should we log? (but we don't have any logger yet nor logger configuration, see next point)
- should we call `on_error` (but `write` is not yet async so it cannot call hooks yet)

See also:
- https://github.com/aio-libs/aiohttp/issues/1790
- https://github.com/channelcat/sanic/issues/1130

Traceback:

```
Jun 10 03:12:50 scw-8f883c Trefle[6872]: Exception in callback <bound method HTTPProtocol.write of <roll.HTTPProtocol object at 0x7fce04d2f6c8>>
Jun 10 03:12:50 scw-8f883c Trefle[6872]: handle: <Handle HTTPProtocol.write>
Jun 10 03:12:50 scw-8f883c Trefle[6872]: Traceback (most recent call last):
Jun 10 03:12:50 scw-8f883c Trefle[6872]:   File "uvloop/cbhandles.pyx", line 64, in uvloop.loop.Handle._run
Jun 10 03:12:50 scw-8f883c Trefle[6872]:   File "/srv/trefle/venv/lib/python3.6/site-packages/roll/__init__.py", line 522, in write
Jun 10 03:12:50 scw-8f883c Trefle[6872]:     self.transport.write(payload)
Jun 10 03:12:50 scw-8f883c Trefle[6872]:   File "uvloop/handles/stream.pyx", line 636, in uvloop.loop.UVStream.write
Jun 10 03:12:50 scw-8f883c Trefle[6872]:   File "uvloop/handles/handle.pyx", line 165, in uvloop.loop.UVHandle._ensure_alive
Jun 10 03:12:50 scw-8f883c Trefle[6872]: RuntimeError: unable to perform operation on <UnixTransport closed=True reading=False 0x7fce04d09048>; the handler is closed
```