### PR TITLE
Make uvloop an optional dependency

### DIFF
--- a/docs/how-to/advanced.md
+++ b/docs/how-to/advanced.md
@@ -119,6 +119,10 @@ with `app = Roll()`, then you need to issue this command line:
 See [gunicorn documentation](http://docs.gunicorn.org/en/stable/settings.html)
 for more details about the available arguments.
 
+Note: it's also recommended to install [uvloop](https://github.com/MagicStack/uvloop)
+as a faster `asyncio` event loop replacement:
+
+    pip install uvloop
 
 ## How to send custom events
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ autoroutes==0.2.0
 biscuits==0.1.1
 httptools==0.0.11
 multifruits==0.1.1
-uvloop==0.10.1
 websockets==5.0.1

--- a/roll/worker.py
+++ b/roll/worker.py
@@ -2,7 +2,12 @@ import asyncio
 import os
 import socket
 import sys
-import uvloop
+try:
+    import uvloop
+except ImportError:
+    uvloop = None
+    import warnings
+    warnings.warn("You should install uvloop for better performance")
 
 from gunicorn.workers.base import Worker
 
@@ -12,7 +17,8 @@ class Worker(Worker):
     def init_process(self):
         self.server = None
         asyncio.get_event_loop().close()
-        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        if uvloop:
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
         super().init_process()


### PR DESCRIPTION
While we still want to run Roll with uvloop in general, we:
- want to be able to install Roll without uvloop where compilation
  of uvloop is not possible
- want to let the user deal with their own version of uvloop