### PR TITLE
Add responder minimal endpoing in benchs

### DIFF
--- a/benchmarks/responder/app.py
+++ b/benchmarks/responder/app.py
@@ -1,0 +1,17 @@
+import asyncio
+
+import responder
+import uvloop
+
+api = responder.API()
+
+asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+
+@api.route('/hello/minimal')
+async def minimal(request, response):
+    response.media = {'message': 'Hello, World!'}
+
+
+if __name__ == '__main__':
+    api.run(port=8000, access_log=False)

--- a/benchmarks/responder/run.sh
+++ b/benchmarks/responder/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exec python app.py


### PR DESCRIPTION
```
(p3) leonardo:~/W/r/benchmarks (master=) ./bench.sh --frameworks responder                                                                                                                 1ms
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
Running bench for responder on minimal endpoint with 1 worker(s)
INFO: Started server process [11072]
INFO: Waiting for application startup.
INFO: Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
HTTP/1.1 200 OK
content-type: application/json
date: Sat, 10 Nov 2018 18:44:48 GMT
server: uvicorn
transfer-encoding: chunked

{
    "message": "Hello, World!"
}

Running 10s test @ http://127.0.0.1:8000/hello/minimal
  20 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    28.51ms    4.99ms  67.32ms   84.93%
    Req/Sec   175.84     25.86   222.00     77.75%
  35052 requests in 10.02s, 5.75MB read
Requests/sec:   3499.89
Transfer/sec:    587.87KB

real	0m10,027s
user	0m0,147s
sys	0m0,630s
INFO: Stopping server process [11072]
INFO: Waiting for application shutdown.
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
(p3) leonardo:~/W/r/benchmarks (master=) ./bench.sh --frameworks roll                                                                                                                11s 659ms
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
Running bench for roll on minimal endpoint with 1 worker(s)
HTTP/1.1 200 OK
Content-Length: 27
Content-Type: application/json; charset=utf-8

{
    "message": "Hello, World!"
}

Running 10s test @ http://127.0.0.1:8000/hello/minimal
  20 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.08ms    1.04ms  22.78ms   89.03%
    Req/Sec     1.65k   270.68     6.82k    93.56%
  329588 requests in 10.10s, 35.52MB read
Requests/sec:  32635.47
Transfer/sec:      3.52MB

real	0m10,111s
user	0m0,813s
sys	0m3,960s
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
```