### PR TITLE
Add Quart in benchmarks

### DIFF
--- a/benchmarks/quart/app.py
+++ b/benchmarks/quart/app.py
@@ -1,0 +1,8 @@
+from quart import jsonify, Quart
+
+app = Quart(__name__)
+
+
+@app.route('/hello/minimal')
+async def minimal():
+    return jsonify({'message': 'Hello, World!'})

--- a/benchmarks/quart/run.sh
+++ b/benchmarks/quart/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exec hypercorn app:app --workers $WORKERS

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -2,6 +2,8 @@ aiohttp==3.6.2
 falcon==2.0.0
 gunicorn==20.0.4
 httpie==2.1.0
+hypercorn==0.9.5
+quart==0.12.0
 sanic==20.3.0
 starlette==0.13.4
 trinket==0.1.5


### PR DESCRIPTION
I was curious to see how Quart compare with Roll in our benchmarks,
following Alex comment on https://github.com/abulte/datagouvfr-pgsearch/pull/2
But strangely I don't observe the same results:

Quart:
14645 requests in 10.02s, 2.18MB read
Requests/sec:   1462.21
Transfer/sec:    222.96KB

Roll (master):
256103 requests in 10.01s, 27.60MB read
Requests/sec:  25579.67
Transfer/sec:      2.76MB

So we need to investigate a bit more how we have opposite results and
maybe adapt our benchmarking tools (even if benchmarks are still nothing
more than benchmarks…)